### PR TITLE
Added no_alloc variant

### DIFF
--- a/Examples/decoder.c
+++ b/Examples/decoder.c
@@ -75,11 +75,11 @@ same arguments, and encoder.c does error check.
 #include "liberation.h"
 #include "timing.h"
 
-#define N 10
+#define N 13
 
-enum Coding_Technique {Reed_Sol_Van, Reed_Sol_R6_Op, Cauchy_Orig, Cauchy_Good, Liberation, Blaum_Roth, Liber8tion, RDP, EVENODD, No_Coding};
+enum Coding_Technique {Reed_Sol_Van, Reed_Sol_Van_noalloc, Reed_Sol_R6_Op, Cauchy_Orig, Cauchy_Good, Cauchy_Good_noalloc, Liberation, Liberation_noalloc, Blaum_Roth, Liber8tion, RDP, EVENODD, No_Coding};
 
-char *Methods[N] = {"reed_sol_van", "reed_sol_r6_op", "cauchy_orig", "cauchy_good", "liberation", "blaum_roth", "liber8tion", "rdp", "evenodd", "no_coding"};
+char *Methods[N] = {"reed_sol_van", "reed_sol_van_noalloc", "reed_sol_r6_op", "cauchy_orig", "cauchy_good", "cauchy_good_alloc", "liberation", "liberation_noalloc", "blaum_roth", "liber8tion", "rdp", "evenodd", "no_coding"};
 
 /* Global variables for signal handler */
 enum Coding_Technique method;
@@ -142,7 +142,7 @@ int main (int argc, char **argv) {
 	assert(curdir == getcwd(curdir, 1000));
 	
 	/* Begin recreation of file names */
-	cs1 = (char*)malloc(sizeof(char)*strlen(argv[1]));
+	cs1 = (char*)malloc(sizeof(char)*strlen(argv[1])+1);
 	cs2 = strrchr(argv[1], '/');
 	if (cs2 != NULL) {
 		cs2++;
@@ -220,12 +220,18 @@ int main (int argc, char **argv) {
 	md = strlen(temp);
 	timing_set(&t3);
 
+	int matrix_n[k*m];
+	int bitmatrix_n[k*m*w*w];
+
 	/* Create coding matrix or bitmatrix */
 	switch(tech) {
 		case No_Coding:
 			break;
 		case Reed_Sol_Van:
 			matrix = reed_sol_vandermonde_coding_matrix(k, m, w);
+			break;
+		case Reed_Sol_Van_noalloc:
+			matrix = reed_sol_vandermonde_coding_matrix_noalloc(k, m, w, matrix_n);
 			break;
 		case Reed_Sol_R6_Op:
 			matrix = reed_sol_r6_coding_matrix(k, w);
@@ -238,8 +244,15 @@ int main (int argc, char **argv) {
 			matrix = cauchy_good_general_coding_matrix(k, m, w);
 			bitmatrix = jerasure_matrix_to_bitmatrix(k, m, w, matrix);
 			break;
+		case Cauchy_Good_noalloc:
+			matrix = cauchy_good_general_coding_matrix_noalloc(k, m, w, matrix_n);
+			bitmatrix = jerasure_matrix_to_bitmatrix_noalloc(k, m, w, matrix, bitmatrix_n);
+			break;
 		case Liberation:
 			bitmatrix = liberation_coding_bitmatrix(k, w);
+			break;
+		case Liberation_noalloc:
+			bitmatrix = liberation_coding_bitmatrix_noalloc(k, w, bitmatrix_n);
 			break;
 		case Blaum_Roth:
 			bitmatrix = blaum_roth_coding_bitmatrix(k, w);
@@ -321,8 +334,14 @@ int main (int argc, char **argv) {
 		if (tech == Reed_Sol_Van || tech == Reed_Sol_R6_Op) {
 			i = jerasure_matrix_decode(k, m, w, matrix, 1, erasures, data, coding, blocksize);
 		}
+		else if (tech == Reed_Sol_Van_noalloc) {
+			i = jerasure_matrix_decode_data(k, m, w, matrix, 1, erasures, data, coding, blocksize);
+		}
 		else if (tech == Cauchy_Orig || tech == Cauchy_Good || tech == Liberation || tech == Blaum_Roth || tech == Liber8tion) {
 			i = jerasure_schedule_decode_lazy(k, m, w, bitmatrix, erasures, data, coding, blocksize, packetsize, 1);
+		}
+		else if (tech == Cauchy_Good_noalloc || tech == Liberation_noalloc) {
+			i = jerasure_schedule_decode_data_lazy(k, m, w, bitmatrix, erasures, data, coding, blocksize, packetsize, 1);
 		}
 		else {
 			fprintf(stderr, "Not a valid coding technique.\n");

--- a/include/cauchy.h
+++ b/include/cauchy.h
@@ -49,6 +49,13 @@ extern void cauchy_improve_coding_matrix(int k, int m, int w, int *matrix);
 extern int *cauchy_good_general_coding_matrix(int k, int m, int w);
 extern int cauchy_n_ones(int n, int w);
 
+/*
+ * No Memory Alloc
+ */
+extern int *cauchy_original_coding_matrix_noalloc(int k, int m, int w, int *matrix);
+extern int *cauchy_xy_coding_matrix_noalloc(int k, int m, int w, int *x, int *y, int *matrix);
+extern int *cauchy_good_general_coding_matrix_noalloc(int k, int m, int w, int *matrix);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/galois.h
+++ b/include/galois.h
@@ -47,6 +47,7 @@ extern "C" {
 #endif
 
 extern int galois_init_default_field(int w);
+extern int galois_init_default_field_noalloc(int w);
 extern int galois_uninit_field(int w);
 extern void galois_change_technique(gf_t *gf, int w);
 

--- a/include/jerasure.h
+++ b/include/jerasure.h
@@ -128,6 +128,13 @@ int **jerasure_dumb_bitmatrix_to_schedule(int k, int m, int w, int *bitmatrix);
 int **jerasure_smart_bitmatrix_to_schedule(int k, int m, int w, int *bitmatrix);
 int ***jerasure_generate_schedule_cache(int k, int m, int w, int *bitmatrix, int smart);
 
+/*
+ * No Memory Alloc
+ */
+int *jerasure_matrix_to_bitmatrix_noalloc(int k, int m, int w, int *matrix, int *bitmatrix);
+int **jerasure_dumb_bitmatrix_to_schedule_noalloc(int k, int m, int w, int *bitmatrix, int **schedule);
+int **jerasure_smart_bitmatrix_to_schedule_noalloc(int k, int m, int w, int *bitmatrix, int **schedule);
+
 void jerasure_free_schedule(int **schedule);
 void jerasure_free_schedule_cache(int k, int m, int ***cache);
 
@@ -205,6 +212,11 @@ int jerasure_make_decoding_bitmatrix(int k, int m, int w, int *matrix, int *eras
                                   int *decoding_matrix, int *dm_ids);
 
 int *jerasure_erasures_to_erased(int k, int m, int *erasures);
+
+/*
+ * No Memory Alloc
+ */
+int *jerasure_erasures_to_erased_noalloc(int k, int m, int *erasures, int *erased);
 
 /* ------------------------------------------------------------ */
 /* These perform dot products and schedules. -------------------*/

--- a/include/liberation.h
+++ b/include/liberation.h
@@ -47,6 +47,10 @@ extern int *liberation_coding_bitmatrix(int k, int w);
 extern int *liber8tion_coding_bitmatrix(int k);
 extern int *blaum_roth_coding_bitmatrix(int k, int w);
 
+/*
+ * No Memory Alloc
+ */
+extern int *liberation_coding_bitmatrix_noalloc(int k, int w, int *matrix);
 #ifdef __cplusplus
 }
 #endif

--- a/include/reed_sol.h
+++ b/include/reed_sol.h
@@ -54,6 +54,13 @@ extern void reed_sol_galois_w08_region_multby_2(char *region, int nbytes);
 extern void reed_sol_galois_w16_region_multby_2(char *region, int nbytes);
 extern void reed_sol_galois_w32_region_multby_2(char *region, int nbytes);
 
+/*
+ * No Memory Alloc
+ */
+extern int *reed_sol_vandermonde_coding_matrix_noalloc(int k, int m, int w, int *matrix);
+extern int *reed_sol_extended_vandermonde_matrix_noalloc(int rows, int cols, int w, int *matrix);
+extern int *reed_sol_big_vandermonde_distribution_matrix_noalloc(int rows, int cols, int w, int *matrix);
+extern int *reed_sol_r6_coding_matrix_noalloc(int k, int w, int *matrix);
 #ifdef __cplusplus
 }
 #endif

--- a/src/cauchy.c
+++ b/src/cauchy.c
@@ -128,14 +128,10 @@ int cauchy_n_ones(int n, int w)
   return no;
 }
   
-int *cauchy_original_coding_matrix(int k, int m, int w)
+inline int *cauchy_original_coding_matrix_setup(int k, int m, int w, int *matrix)
 {
-  int *matrix;
   int i, j, index;
 
-  if (w < 31 && (k+m) > (1 << w)) return NULL;
-  matrix = talloc(int, k*m);
-  if (matrix == NULL) return NULL;
   index = 0;
   for (i = 0; i < m; i++) {
     for (j = 0; j < k; j++) {
@@ -146,13 +142,28 @@ int *cauchy_original_coding_matrix(int k, int m, int w)
   return matrix;
 }
 
-int *cauchy_xy_coding_matrix(int k, int m, int w, int *X, int *Y)
+int *cauchy_original_coding_matrix(int k, int m, int w)
 {
-  int index, i, j;
   int *matrix;
 
+  if (w < 31 && (k+m) > (1 << w)) return NULL;
+
   matrix = talloc(int, k*m);
-  if (matrix == NULL) { return NULL; }
+  if (matrix == NULL) return NULL;
+
+  return cauchy_original_coding_matrix_setup(k, m, w, matrix);
+}
+
+int *cauchy_original_coding_matrix_noalloc(int k, int m, int w, int *matrix)
+{
+  if (w < 31 && (k+m) > (1 << w)) return NULL;
+  return cauchy_original_coding_matrix_setup(k, m, w, matrix);
+}
+
+inline int *cauchy_xy_coding_matrix_setup(int k, int m, int w, int *X, int *Y, int *matrix)
+{
+  int index, i, j;
+
   index = 0;
   for (i = 0; i < m; i++) {
     for (j = 0; j < k; j++) {
@@ -161,6 +172,21 @@ int *cauchy_xy_coding_matrix(int k, int m, int w, int *X, int *Y)
     }
   }
   return matrix;
+}
+
+int *cauchy_xy_coding_matrix(int k, int m, int w, int *X, int *Y)
+{
+  int *matrix;
+
+  matrix = talloc(int, k*m);
+  if (matrix == NULL) { return NULL; }
+  
+  return cauchy_xy_coding_matrix_setup(k, m, w, X, Y, matrix);
+}
+
+int *cauchy_xy_coding_matrix_noalloc(int k, int m, int w, int *X, int *Y, int *matrix)
+{
+    return cauchy_xy_coding_matrix_setup(k, m, w, X, Y, matrix);
 }
 
 void cauchy_improve_coding_matrix(int k, int m, int w, int *matrix)
@@ -206,13 +232,11 @@ void cauchy_improve_coding_matrix(int k, int m, int w, int *matrix)
   }
 }
 
-int *cauchy_good_general_coding_matrix(int k, int m, int w)
+inline int *cauchy_good_general_coding_matrix_setup(int k, int m, int w, int *matrix)
 {
-  int *matrix, i;
+  int i;
 
   if (m == 2 && k <= cbest_max_k[w]) {
-    matrix = talloc(int, k*m);
-    if (matrix == NULL) return NULL;
     if (!cbest_init) {
       cbest_init = 1;
       cbest_all[0] = cbest_0; cbest_all[1] = cbest_1; cbest_all[2] = cbest_2; cbest_all[3] = cbest_3; cbest_all[4] =
@@ -230,11 +254,25 @@ int *cauchy_good_general_coding_matrix(int k, int m, int w)
     }
     return matrix;
   } else {
-    matrix = cauchy_original_coding_matrix(k, m, w);
+    matrix = cauchy_original_coding_matrix_noalloc(k, m, w, matrix);
     if (matrix == NULL) return NULL;
     cauchy_improve_coding_matrix(k, m, w, matrix);
     return matrix;
   }
+}
+
+int *cauchy_good_general_coding_matrix(int k, int m, int w)
+{
+    int *matrix;
+    matrix = talloc(int, k*m);
+    if (matrix == NULL) return NULL;
+
+    return cauchy_good_general_coding_matrix_setup(k, m, w, matrix);
+}
+
+int *cauchy_good_general_coding_matrix_noalloc(int k, int m, int w, int *matrix)
+{
+    return cauchy_good_general_coding_matrix_setup(k, m, w, matrix);
 }
 
 static int cbest_2[3] = { 1, 2, 3 };

--- a/src/galois.c
+++ b/src/galois.c
@@ -53,7 +53,13 @@
 #include "galois.h"
 
 #define MAX_GF_INSTANCES 64
-gf_t *gfp_array[MAX_GF_INSTANCES] = { 0 };
+
+#define SCRATCH_SIZE    (256 << 10)
+#define SCRATCH_POOL_SIZE   (SCRATCH_SIZE * 4)
+char scratch_pool[SCRATCH_POOL_SIZE] = { 0 };
+gf_t gfp_array_noalloc[4];
+
+gf_t* gfp_array[MAX_GF_INSTANCES] = { 0 };
 int  gfp_is_composite[MAX_GF_INSTANCES] = { 0 };
 
 gf_t *galois_get_field_ptr(int w)
@@ -170,6 +176,29 @@ gf_t* galois_init_composite_field(int w,
   return gfp;
 }
 
+int galois_init_default_field_noalloc(int w)
+{
+  int tar = 0;
+  switch(w) {
+    case 8:
+      tar = 0;
+      break;
+    case 16:
+      tar = 1;
+      break;
+    case 32:
+      tar = 2;
+      break;
+    default:
+      return EINVAL;
+  }
+  char* ptr = scratch_pool + tar * SCRATCH_SIZE;
+  gfp_array[w] = &gfp_array_noalloc[tar];
+  if (!gf_init_hard(gfp_array[w], w, GF_MULT_DEFAULT, GF_REGION_DEFAULT, GF_DIVIDE_DEFAULT, 0, 0, 0, NULL, ptr))
+    return EINVAL;
+  return 0;
+}
+
 int galois_init_default_field(int w)
 {
   if (gfp_array[w] == NULL) {
@@ -201,15 +230,26 @@ static void galois_init(int w)
     assert(0);
   }
 
-  switch (galois_init_default_field(w)) {
-  case ENOMEM:
-    fprintf(stderr, "ERROR -- cannot allocate memory for Galois field w=%d\n", w);
-    assert(0);
-    break;
-  case EINVAL:
-    fprintf(stderr, "ERROR -- cannot init default Galois field for w=%d\n", w);
-    assert(0);
-    break;
+  int ret = 0;
+  switch (w) {
+    case 8:
+    case 16:
+    case 32:
+      ret = galois_init_default_field_noalloc(w);
+      break;
+    default:
+      ret = galois_init_default_field(w);
+      break;
+  }
+  switch(ret) {
+    case ENOMEM:
+      fprintf(stderr, "ERROR -- cannot allocate memory for Galois field w=%d\n", w);
+      assert(0);
+      break;
+    case EINVAL:
+      fprintf(stderr, "ERROR -- cannot init default Galois field for w=%d\n", w);
+      assert(0);
+      break;
   }
 }
 

--- a/src/liberation.c
+++ b/src/liberation.c
@@ -54,13 +54,11 @@
 
 #define talloc(type, num) (type *) malloc(sizeof(type)*(num))
 
-int *liberation_coding_bitmatrix(int k, int w)
+int *liberation_coding_bitmatrix_setup(int k, int w, int *matrix)
 {
-  int *matrix, i, j, index;
+  int i, j, index;
 
   if (k > w) return NULL;
-  matrix = talloc(int, 2*k*w*w);
-  if (matrix == NULL) return NULL;
   bzero(matrix, sizeof(int)*2*k*w*w);
   
   /* Set up identity matrices */
@@ -89,6 +87,20 @@ int *liberation_coding_bitmatrix(int k, int w)
   return matrix;
 }
   
+int *liberation_coding_bitmatrix_noalloc(int k, int w, int *matrix)
+{
+  return liberation_coding_bitmatrix_setup(k, w, matrix);
+}
+
+int *liberation_coding_bitmatrix(int k, int w)
+{
+  int *matrix;
+  matrix = talloc(int, 2*k*w*w);
+  if (matrix == NULL) return NULL;
+  int *ret = liberation_coding_bitmatrix_setup(k, w, matrix);
+  if (ret == NULL) free(matrix);
+  return ret;
+}
 
 int *liber8tion_coding_bitmatrix(int k)
 {


### PR DESCRIPTION
### Description

JErasure Library uses lots of heap allocation for temporary structure.
The large number of small allocation/deallocation may have performance impact.
When used in NIF, some memory issue is encountered (Random Segmentation Fault)
### Purposed Solution

Added a separate code path which avoid memory allocation (structures are allocated by caller beforehand), putting temporary structure in stack.
### Related Issue

https://github.com/leo-project/leofs/issues/440
### Relate PR

https://github.com/leo-project/jerasure/pull/3
https://github.com/leo-project/jerasure/pull/4
https://github.com/leo-project/leo_erasure/pull/1
